### PR TITLE
Replace copy-paste package with atom's own clipboard functionality

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,6 @@ import configuration from './config';
 
 import HTMLgenerator from './html_generator';
 import RTFgenerator from './rtf_generator';
-import copy from 'copy-paste';
 
 
 export default {
@@ -38,7 +37,7 @@ export default {
   },
 
   copy_to_clipboard( content ){
-    return copy.copy( content );
+    atom.clipboard.write(content);
   },
 
   copy_done( result ){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "copy-with-style",
+  "version": "1.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "copy-with-style",
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "color": "1.0.3"
+      },
+      "engines": {
+        "atom": ">=1.0.0 <2.0.0"
+      }
+    },
+    "node_modules/color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
+      "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
+      "dependencies": {
+        "color-convert": "^1.8.2",
+        "color-string": "^1.4.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    }
+  },
+  "dependencies": {
+    "color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
+      "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
+      "requires": {
+        "color-convert": "^1.8.2",
+        "color-string": "^1.4.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "copy-paste": "1.3.0",
     "color": "1.0.3"
   }
 }


### PR DESCRIPTION
For me (Ubuntu 21.10, Atom 1.57.0), the pretty old copy-paste package didn't seem to work. I replaced it with Atom's built-in `atom.clipboard.write()`.